### PR TITLE
feat: Add support for pull_request.ready_for_review event 

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ Toolkit.run(
     event: [
       'pull_request.opened',
       'pull_request.synchronize',
+      'pull_request.ready_for_review',
     ],
     secrets: ['GITHUB_TOKEN'],
   },


### PR DESCRIPTION
### What

When a PR is transited from draft to ready to review, it shows an error as following: 
```
error     Event `pull_request.ready_for_review` is not supported by this action.
```
After I dig into the code I found that the action only allow `pull_request.open` and `pull_request.synchronize` event but not `pull_request.ready_for_review`. 

### How

By adding `pull_request.ready_for_review` into event list should solve the issue. 
